### PR TITLE
`watch` arguments are optional

### DIFF
--- a/txkazoo/client.py
+++ b/txkazoo/client.py
@@ -75,7 +75,7 @@ class _RunCallbacksInReactorThreadWrapper(object):
         APIs.
         """
         bound_args = signature(f).bind(*args, **kwargs)
-        orig_watch = bound_args.arguments["watch"]
+        orig_watch = bound_args.arguments.get("watch")
 
         if orig_watch is not None:
             wrapped_watch = partial(self._call_in_reactor_thread, orig_watch)

--- a/txkazoo/test/test_client.py
+++ b/txkazoo/test/test_client.py
@@ -93,6 +93,15 @@ class _RunCallbacksInReactorThreadTests(SynchronousTestCase):
         self.client.watch(event)
         self.assertIdentical(self.received_event, event)
 
+    def test_optional_watch_functions(self):
+        """
+        Methods that take an optional watch function still work when the watch
+        function is not provided.
+        """
+        self.wrapper.get("abc")
+        event = object()
+        self.assertEqual(self.client.watch, None)
+
 
 class TxKazooClientTests(SynchronousTestCase):
     """


### PR DESCRIPTION
trivial fix: the code was assuming that any method with a `watch` argument should always have a `watch` argument passed.